### PR TITLE
Fix gantt_chart key across frontend

### DIFF
--- a/code/frontend/ideation-station-frontend/src/App.vue
+++ b/code/frontend/ideation-station-frontend/src/App.vue
@@ -49,7 +49,7 @@
         :dos="selectedIdea.dos"
         :donts="selectedIdea.donts"
         :milestone_plan="selectedIdea.milestone_plan"
-        :gant_chart="selectedIdea.gant_chart"
+        :gantt_chart="selectedIdea.gantt_chart"
         :raid_chart="selectedIdea.raid_chart"
         :task_table="selectedIdea.task_table"
       />
@@ -124,7 +124,7 @@ const fetchIdeas = async () => {
       dos: record.idea_output.markdown.dos,
       donts: record.idea_output.markdown.donts,
       milestone_plan: record.idea_output.plans.milestone_plan,
-      gant_chart: record.idea_output.plans.gant_chart,
+      gantt_chart: record.idea_output.plans.gantt_chart,
       raid_chart: record.idea_output.plans.raid_chart,
       task_table: record.idea_output.plans.task_table,
       created: record.created

--- a/code/frontend/ideation-station-frontend/src/components/InputForm.vue
+++ b/code/frontend/ideation-station-frontend/src/components/InputForm.vue
@@ -29,7 +29,7 @@
           :dos="dos"
           :donts="donts"
           :milestone_plan="milestone_plan"
-          :gant_chart="gant_chart"
+          :gantt_chart="gantt_chart"
           :raid_chart="raid_chart"
           :task_table="task_table"
 
@@ -68,7 +68,7 @@
             dos: null,
             donts: null,
             milestone_plan: null,
-            gant_chart: null,
+            gantt_chart: null,
             raid_chart: null,
             task_table: null,
             loading: false
@@ -89,7 +89,7 @@
                 this.dos = null;
                 this.donts = null;
                 this.milestone_plan = null;
-                this.gant_chart = null;
+                this.gantt_chart = null;
                 this.raid_chart = null;
                 this.task_table = null;
 
@@ -119,7 +119,7 @@
                     this.dos = marked(jsonResponse.output.markdown.dos, null, 2);
                     this.donts = marked(jsonResponse.output.markdown.donts, null, 2);
                     this.milestone_plan = marked(jsonResponse.output.plans.milestone_plan, null, 2);
-                    this.gant_chart = marked(jsonResponse.output.plans.gant_chart, null, 2);
+                    this.gantt_chart = marked(jsonResponse.output.plans.gantt_chart, null, 2);
                     this.raid_chart = marked(jsonResponse.output.plans.raid_chart, null, 2);
                     this.task_table = marked(jsonResponse.output.plans.task_table, null, 2);
 

--- a/code/frontend/ideation-station-frontend/src/components/ResultsDisplay.vue
+++ b/code/frontend/ideation-station-frontend/src/components/ResultsDisplay.vue
@@ -41,9 +41,9 @@
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Milestone Plan:</h3>
         <div v-html="milestone_plan" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
       </div>
-      <div v-if="gant_chart">
+      <div v-if="gantt_chart">
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Gant Chart:</h3>
-        <div v-html="gant_chart" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
+        <div v-html="gantt_chart" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
       </div>
       <div v-if="raid_chart">
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Raid Chart:</h3>
@@ -118,7 +118,7 @@
         required: false,
         default: null
       },
-      gant_chart: {
+      gantt_chart: {
         type: String,
         required: false,
         default: null

--- a/code/frontend/kometa/src/App.vue
+++ b/code/frontend/kometa/src/App.vue
@@ -63,7 +63,7 @@
           dos: record.idea_output?.concept?.dos,
           donts: record.idea_output?.concept?.donts,
           milestone_plan: record.idea_output?.plans?.milestone_plan,
-          gant_chart: record.idea_output?.plans?.gant_chart,
+          gantt_chart: record.idea_output?.plans?.gantt_chart,
           raid_chart: record.idea_output?.plans?.raid_chart,
           task_table: record.idea_output?.plans?.task_table,
           created: record.created

--- a/code/frontend/kometa/src/services/apiService.js
+++ b/code/frontend/kometa/src/services/apiService.js
@@ -17,7 +17,7 @@ export const fetchIdea = async (id) => {
       dos: record.idea_output?.concept?.dos,
       donts: record.idea_output?.concept?.donts,
       milestone_plan: record.idea_output?.plans?.milestone_plan,
-      gant_chart: record.idea_output?.plans?.gant_chart,
+      gantt_chart: record.idea_output?.plans?.gantt_chart,
       raid_chart: record.idea_output?.plans?.raid_chart,
       task_table: record.idea_output?.plans?.task_table,
     };

--- a/code/frontend/kometa/src/store.js
+++ b/code/frontend/kometa/src/store.js
@@ -60,7 +60,7 @@ export const useAuthStore = defineStore('auth', {
           dos: record.idea_output?.concept?.dos,
           donts: record.idea_output?.concept?.donts,
           milestone_plan: record.idea_output?.plans?.milestone_plan,
-          gant_chart: record.idea_output?.plans?.gant_chart,
+          gantt_chart: record.idea_output?.plans?.gantt_chart,
           raid_chart: record.idea_output?.plans?.raid_chart,
           task_table: record.idea_output?.plans?.task_table,
           created: record.created

--- a/code/frontend/vue-project/src/components/InputForm.vue
+++ b/code/frontend/vue-project/src/components/InputForm.vue
@@ -32,7 +32,7 @@
           :dos="dos"
           :donts="donts"
           :milestone_plan="milestone_plan"
-          :gant_chart="gant_chart"
+          :gantt_chart="gantt_chart"
           :raid_chart="raid_chart"
           :task_table="task_table"
 
@@ -66,7 +66,7 @@
             dos: null,
             donts: null,
             milestone_plan: null,
-            gant_chart: null,
+            gantt_chart: null,
             raid_chart: null,
             task_table: null,
             loading: false
@@ -87,7 +87,7 @@
                 this.dos = null;
                 this.donts = null;
                 this.milestone_plan = null;
-                this.gant_chart = null;
+                this.gantt_chart = null;
                 this.raid_chart = null;
                 this.task_table = null;
 
@@ -117,7 +117,7 @@
                     this.dos = marked(jsonResponse.output.markdown.dos, null, 2);
                     this.donts = marked(jsonResponse.output.markdown.donts, null, 2);
                     this.milestone_plan = marked(jsonResponse.output.plans.milestone_plan, null, 2);
-                    this.gant_chart = marked(jsonResponse.output.plans.gant_chart, null, 2);
+                    this.gantt_chart = marked(jsonResponse.output.plans.gantt_chart, null, 2);
                     this.raid_chart = marked(jsonResponse.output.plans.raid_chart, null, 2);
                     this.task_table = marked(jsonResponse.output.plans.task_table, null, 2);
 

--- a/code/frontend/vue-project/src/components/ResultsDisplay.vue
+++ b/code/frontend/vue-project/src/components/ResultsDisplay.vue
@@ -42,9 +42,9 @@
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Milestone Plan:</h3>
         <div v-html="milestone_plan" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
       </div>
-      <div v-if="gant_chart">
+      <div v-if="gantt_chart">
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Gant Chart:</h3>
-        <div v-html="gant_chart" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
+        <div v-html="gantt_chart" class="bg-weather-secondary text-white px-4 py-2 rounded-lg mt-4 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus:ring-blue-500 dark:focus:ring-opacity-50 hover:bg-weather-secondary duration-150"></div>
       </div>
       <div v-if="raid_chart">
         <h3 class="shadow-lg bg-weather-primary text-white text-3xl font-Roboto p-2">Raid Chart:</h3>
@@ -119,7 +119,7 @@
         required: false,
         default: null
       },
-      gant_chart: {
+      gantt_chart: {
         type: String,
         required: false,
         default: null


### PR DESCRIPTION
## Summary
- fix typos of `gant_chart` to `gantt_chart` across all frontend sources
- keep backend class and parsers using `gantt_chart`

## Testing
- `npm run build` *(fails: vite not found)*